### PR TITLE
replace deprecated telescope diagnostics command

### DIFF
--- a/lua/user/whichkey.lua
+++ b/lua/user/whichkey.lua
@@ -132,11 +132,11 @@ local mappings = {
     name = "LSP",
     a = { "<cmd>lua vim.lsp.buf.code_action()<cr>", "Code Action" },
     d = {
-      "<cmd>Telescope lsp_document_diagnostics<cr>",
+      "<cmd>Telescope diagnostics bufnr=0<cr>",
       "Document Diagnostics",
     },
     w = {
-      "<cmd>Telescope lsp_workspace_diagnostics<cr>",
+      "<cmd>Telescope diagnostics<cr>",
       "Workspace Diagnostics",
     },
     f = { "<cmd>lua vim.lsp.buf.formatting()<cr>", "Format" },


### PR DESCRIPTION
The old telescope diagnostics command for document and work-spaces has been deprecated, so replaced them with the new suggested command in the change-log number#1553 of telescope
![Telescope_changelog_1553](https://user-images.githubusercontent.com/68259771/147845036-a04852e5-1de0-4ced-b511-fa050de1f091.png)
