### PR TITLE
line diagnostics is deprecated

### DIFF
--- a/lua/user/lsp/handlers.lua
+++ b/lua/user/lsp/handlers.lua
@@ -76,7 +76,7 @@ local function lsp_keymaps(bufnr)
     bufnr,
     "n",
     "gl",
-    '<cmd>lua vim.lsp.diagnostic.show_line_diagnostics({ border = "rounded" })<CR>',
+    '<cmd>lua vim.diagnostic.open_float(0, { border = "rounded" })<CR>',
     opts
   )
   vim.api.nvim_buf_set_keymap(bufnr, "n", "]d", '<cmd>lua vim.diagnostic.goto_next({ border = "rounded" })<CR>', opts)


### PR DESCRIPTION
After using gl to show line diagnostics I got an error that it is deprecated.
Used code from here to fix it: https://www.reddit.com/r/neovim/comments/qd3v4h/psa_vimdiagnostics_api_has_changed_a_little_bit/