### PR TITLE
Make search highlight keybind be a toggle

### DIFF
--- a/lua/user/whichkey.lua
+++ b/lua/user/whichkey.lua
@@ -88,7 +88,7 @@ local mappings = {
   ["w"] = { "<cmd>w!<CR>", "Save" },
   ["q"] = { "<cmd>q!<CR>", "Quit" },
   ["c"] = { "<cmd>Bdelete!<CR>", "Close Buffer" },
-  ["h"] = { "<cmd>nohlsearch<CR>", "No Highlight" },
+  ["h"] = { "<cmd>set invhlsearch<CR>", "Toggle Highlight" },
   ["f"] = {
     "<cmd>lua require('telescope.builtin').find_files(require('telescope.themes').get_dropdown{previewer = false})<cr>",
     "Find files",


### PR DESCRIPTION
The keybind now inverts the current `hlsearch`-option, so it's also useful to (re-)enable the option as needed.