### PR TITLE
fix error in lsp/handler when cmp_nvim_lsp plugin is not available

### DIFF
--- a/lua/user/lsp/handlers.lua
+++ b/lua/user/lsp/handlers.lua
@@ -95,10 +95,8 @@ end
 local capabilities = vim.lsp.protocol.make_client_capabilities()
 
 local status_ok, cmp_nvim_lsp = pcall(require, "cmp_nvim_lsp")
-if not status_ok then
-  return
+if status_ok then
+  M.capabilities = cmp_nvim_lsp.update_capabilities(capabilities)
 end
-
-M.capabilities = cmp_nvim_lsp.update_capabilities(capabilities)
 
 return M


### PR DESCRIPTION
Was the cause for 
```
E5113: Error while calling lua chunk: /Users/username/.config/nvim/lua/user/lsp/init.lua:7: attempt to index a
boolean value
```
Mentioned in #21 
