### PR TITLE
fix(cmp): complete setup for command mode autocomplete

### DIFF
--- a/lua/user/cmp.lua
+++ b/lua/user/cmp.lua
@@ -127,3 +127,9 @@ cmp.setup {
     native_menu = false,
   },
 }
+
+cmp.setup.cmdline(':', {
+  sources = {
+    { name = "cmdline" },
+  },
+})


### PR DESCRIPTION
Even though the [hrsh7th/cmp-cmdline](https://github.com/hrsh7th/cmp-cmdline) plugin is installed in [`plugins.lua`](https://github.com/LunarVim/Neovim-from-scratch/blob/master/lua/user/plugins.lua#L70), it was never properly set-up in `cmp.lua`. This PR finishes the set-up of the plugin and enables autocomplete for the command line.

Before setting up (the menu only shows up when I press Tab):
![Before set-up](https://user-images.githubusercontent.com/57580593/149498751-ca8236ae-e476-469a-b73a-22adb73be6a3.png)

After setting up (the menu immediately shows up on typing):
![After set-up](https://user-images.githubusercontent.com/57580593/149498850-1114a18e-a6c3-4c7d-8ea4-f2b7b384f7f8.png)