### PR TITLE
Stop new line comments

### DIFF
--- a/lua/user/options.lua
+++ b/lua/user/options.lua
@@ -38,4 +38,4 @@ vim.opt.shortmess:append "c"
 
 vim.cmd "set whichwrap+=<,>,[,],h,l"
 vim.cmd [[set iskeyword+=-]]
-vim.cmd [[set formatoptions-=cro]] -- TODO: this doesn't seem to work
+vim.cmd [[au BufEnter * set fo-=c fo-=r fo-=o]] -- Stop newline comments.


### PR DESCRIPTION
This really works.
vim.cmd [[au BufEnter * set fo-=c fo-=r fo-=o]] -- Stop new line comments.