### PR TITLE
documentation is deprecated, change it to window documentation

### DIFF
--- a/lua/user/cmp.lua
+++ b/lua/user/cmp.lua
@@ -117,8 +117,10 @@ cmp.setup {
     behavior = cmp.ConfirmBehavior.Replace,
     select = false,
   },
-  documentation = {
-    border = { "╭", "─", "╮", "│", "╯", "─", "╰", "│" },
+  window = {
+    documentation = {
+      border = { "╭", "─", "╮", "│", "╯", "─", "╰", "│" },
+    }
   },
   experimental = {
     ghost_text = false,


### PR DESCRIPTION
for some reason it's deprecated, I found it while following your tutorial. Written this way u don't get an error

https://github.com/hrsh7th/nvim-cmp/issues/231