### PR TITLE
Removed unnecessary use of `vim.cmd` in plugins.lua

### DIFF
--- a/lua/user/plugins.lua
+++ b/lua/user/plugins.lua
@@ -12,16 +12,16 @@ if fn.empty(fn.glob(install_path)) > 0 then
     install_path,
   }
   print "Installing packer close and reopen Neovim..."
-  vim.cmd [[packadd packer.nvim]]
+  require('packer').packadd = 'packer.nvim'
 end
 
 -- Autocommand that reloads neovim whenever you save the plugins.lua file
-vim.cmd [[
-  augroup packer_user_config
-    autocmd!
-    autocmd BufWritePost plugins.lua source <afile> | PackerSync
-  augroup end
-]]
+local group = vim.api.nvim_create_augroup("packer_user_config", { clear = true })
+vim.api.nvim_create_autocmd("BufWritePost", {
+  command = "source <afile> | PackerSync",
+  pattern = "plugins.lua",
+  group = group,
+})
 
 -- Use a protected call so we don't error out on first use
 local status_ok, packer = pcall(require, "packer")


### PR DESCRIPTION
In neovim 0.7 using `vim.cmd` is no longer needed for autocmds, also using `packadd` as in `vim.cmd` was never necessary.