### PR TITLE
Removed deprecated code from `cmp.lua`

### DIFF
--- a/lua/user/cmp.lua
+++ b/lua/user/cmp.lua
@@ -117,11 +117,13 @@ cmp.setup {
     behavior = cmp.ConfirmBehavior.Replace,
     select = false,
   },
-  documentation = {
-    border = { "╭", "─", "╮", "│", "╯", "─", "╰", "│" },
-  },
+  window = {
+    documentation = cmp.config.window.bordered(),
+  }
   experimental = {
     ghost_text = false,
+  },
+  view = {
     native_menu = false,
   },
 }

--- a/lua/user/cmp.lua
+++ b/lua/user/cmp.lua
@@ -119,7 +119,7 @@ cmp.setup {
   },
   window = {
     documentation = cmp.config.window.bordered(),
-  }
+  },
   experimental = {
     ghost_text = false,
   },


### PR DESCRIPTION
While going through the tutorial I noticed some messages from `nvim-cmp` yelling at me for using deprecated code this fixes that issue.