### PR TITLE
fix to documentation is deprecated alert message and nvim-tree auto close removed alert message 

### DIFF
--- a/lua/user/cmp.lua
+++ b/lua/user/cmp.lua
@@ -119,9 +119,11 @@ cmp.setup {
     behavior = cmp.ConfirmBehavior.Replace,
     select = false,
   },
-  documentation = {
-    border = { "╭", "─", "╮", "│", "╯", "─", "╰", "│" },
-  },
+  window = {
+    documentation = {
+      border = { "╭", "─", "╮", "│", "╯", "─", "╰", "│" },
+    }
+  }, 
   experimental = {
     ghost_text = false,
     native_menu = false,

--- a/lua/user/nvim-tree.lua
+++ b/lua/user/nvim-tree.lua
@@ -42,7 +42,7 @@ nvim_tree.setup {
     "dashboard",
     "alpha",
   },
-  auto_close = true,
+  auto_close = false,
   open_on_tab = false,
   hijack_cursor = false,
   update_cwd = true,


### PR DESCRIPTION
```
[nvim-cmp] documentation is deprecated.
[nvim-cmp] Please use window.documentation= "native" instead. 
```
to fix this issue changed this 
```
documentation = {
    border = { "╭", "─", "╮", "│", "╯", "─", "╰", "│" },
  },
 ```
to this 
 ```
 window = {
    documentation = {
      border = { "╭", "─", "╮", "│", "╯", "─", "╰", "│" },
    }
  }, 
  ```
and removed this alert

```
[NvimTree] auto close feature has been removed , see note in README (tips & reminder section)
```
by changing 

this `auto_close = true` to `auto_close = false` this
