### PR TITLE
fix: use list of languages treesitter.lua

### DIFF
--- a/lua/user/treesitter.lua
+++ b/lua/user/treesitter.lua
@@ -4,7 +4,7 @@ if not status_ok then
 end
 
 configs.setup {
-  ensure_installed = "maintained", -- one of "all", "maintained" (parsers with maintainers), or a list of languages
+  ensure_installed = { "lua", "rust", "typescript" }, -- one of "all" or a list of languages (https://github.com/nvim-treesitter/nvim-treesitter#supported-languages)
   sync_install = false, -- install languages synchronously (only applied to `ensure_installed`)
   ignore_install = { "" }, -- List of parsers to ignore installing
   autopairs = {


### PR DESCRIPTION
`nvim-treesitter` deprecated `maintained` https://github.com/nvim-treesitter/nvim-treesitter/pull/2809.

This adds a list of languages instead. 

Fixes #130