### PR TITLE
Disable treesitter indent for Python 

### DIFF
--- a/lua/user/treesitter.lua
+++ b/lua/user/treesitter.lua
@@ -15,7 +15,7 @@ configs.setup {
     disable = { "" }, -- list of language that will be disabled
     additional_vim_regex_highlighting = true,
   },
-  indent = { enable = true, disable = { "yaml" } },
+  indent = { enable = true, disable = { "yaml", "python" } },
   context_commentstring = {
     enable = true,
     enable_autocmd = false,


### PR DESCRIPTION
Indent is broken when using Python. More info here: https://github.com/nvim-treesitter/nvim-treesitter/issues/1136#issue-849649622