### PR TITLE
Fix cmp documentation error

### DIFF
--- a/lua/user/cmp.lua
+++ b/lua/user/cmp.lua
@@ -119,8 +119,10 @@ cmp.setup {
     behavior = cmp.ConfirmBehavior.Replace,
     select = false,
   },
-  documentation = {
-    border = { "╭", "─", "╮", "│", "╯", "─", "╰", "│" },
+  window = {
+    documentation = {
+      border = { "╭", "─", "╮", "│", "╯", "─", "╰", "│" },
+    },
   },
   experimental = {
     ghost_text = false,


### PR DESCRIPTION
Fixes the "documentation is deprecated" error message in Neovim 0.7+.