### PR TITLE
Remove deprecated lsp.diagnostic.show_line_diagnostics()

### DIFF
--- a/lua/user/lsp/handlers.lua
+++ b/lua/user/lsp/handlers.lua
@@ -76,7 +76,7 @@ local function lsp_keymaps(bufnr)
     bufnr,
     "n",
     "gl",
-    '<cmd>lua vim.lsp.diagnostic.show_line_diagnostics({ border = "rounded" })<CR>',
+    '<cmd>lua vim.diagnostic.open_float({ border = "rounded" })<CR>'
     opts
   )
   vim.api.nvim_buf_set_keymap(bufnr, "n", "]d", '<cmd>lua vim.diagnostic.goto_next({ border = "rounded" })<CR>', opts)


### PR DESCRIPTION
See "LSP Diagnostics" [here](https://neovim.io/doc/user/deprecated.html).

`vim.lsp.diagnostic.show_line_diagnostics()` has been replaced with `vim.diagnostic.open_float()`