### PR TITLE
fix error in jsonls 'bad argument #1 to 'ipairs' (table expected, got nil)'

### DIFF
--- a/lua/user/lsp/settings/jsonls.lua
+++ b/lua/user/lsp/settings/jsonls.lua
@@ -169,7 +169,7 @@ local schemas = {
 }
 
 local function extend(tab1, tab2)
-  for _, value in ipairs(tab2) do
+  for _, value in ipairs(tab2 or {}) do
     table.insert(tab1, value)
   end
   return tab1


### PR DESCRIPTION
adding the possibility for nil in the local function `extend` fixes the following error:

```
/home/briain/.config/nvim/lua/user/lsp/settings/jsonls.lua:172: bad argument #1 to 'ipairs' (table expected, got nil)
```
