### PR TITLE
fix(nvim-tree): Error: options moved to setup

### DIFF
--- a/lua/user/nvim-tree.lua
+++ b/lua/user/nvim-tree.lua
@@ -1,25 +1,5 @@
 -- following options are the default
 -- each of these are documented in `:help nvim-tree.OPTION_NAME`
-vim.g.nvim_tree_icons = {
-  default = "",
-  symlink = "",
-  git = {
-    unstaged = "",
-    staged = "S",
-    unmerged = "",
-    renamed = "➜",
-    deleted = "",
-    untracked = "U",
-    ignored = "◌",
-  },
-  folder = {
-    default = "",
-    open = "",
-    empty = "",
-    empty_open = "",
-    symlink = "",
-  },
-}
 
 local status_ok, nvim_tree = pcall(require, "nvim-tree")
 if not status_ok then
@@ -43,6 +23,46 @@ vim.api.nvim_create_autocmd("BufEnter", {
 })
 
 nvim_tree.setup {
+  renderer = {
+    icons = {
+      webdev_colors = true,
+      git_placement = "before",
+      padding = " ",
+      symlink_arrow = " ➛ ",
+      show = {
+        file = true,
+        folder = true,
+        folder_arrow = true,
+        git = true,
+      },
+      glyphs = {
+        default = "",
+        symlink = "",
+        git = {
+          unstaged = "",
+          staged = "S",
+          unmerged = "",
+          renamed = "➜",
+          deleted = "",
+          untracked = "U",
+          ignored = "◌",
+        },
+        folder = {
+          default = "",
+          open = "",
+          empty = "",
+          empty_open = "",
+          symlink = "",
+        },
+      },
+    },
+    highlight_git = true,
+    root_folder_modifier = ":t",
+  },
+  hijack_directories = {
+    enable = true,
+    auto_open = true,
+  },
   disable_netrw = true,
   hijack_netrw = true,
   open_on_setup = false,
@@ -103,21 +123,11 @@ nvim_tree.setup {
   },
   actions = {
     open_file = {
+      resize_window = true,
       quit_on_open = true,
       window_picker = {
             enable = false,
       },
     },
   },
-
---  unknown options as of 22.05
---
---  update_to_buf_dir = {
---    enable = true,
---    auto_open = true,
---  },
---  auto_resize = true,
---  git_hl = 1,
---  root_folder_modifier = ":t",
-
 }


### PR DESCRIPTION
Error: Following options were moved to setup, see bit.ly/3vIpEOJ: nvim_tree_root_folder_modifier, nvim_tree_icons, nvim_tree_git_hl

The [migration guide](bit.ly/3vIpEOJ) declares:
g:nvim_tree_icons -> renderer.icons.glyphs
g:nvim_tree_git_hl -> renderer.highlight_git (boolean)
g:nvim_tree_root_folder_modifier -> renderer.root_folder_modifier
g:nvim_tree_auto_resize -> actions.open_file.resize_window
g:nvim_tree_update_to_buf_dir -> hijack_directories 

this commit kicks the error out of my config and fixes #124 