### PR TITLE
fix formatoptions part

### DIFF
--- a/lua/user/options.lua
+++ b/lua/user/options.lua
@@ -43,5 +43,5 @@ end
 
 vim.cmd "set whichwrap+=<,>,[,],h,l"
 vim.cmd [[set iskeyword+=-]]
--- vim.cmd "set formatoptions-=cro" -- This does not seem to work, so the command below replaces it. 
+-- vim.cmd "set formatoptions-=cro" -- This does not seem to work, so the command below works as a substitute.
 vim.cmd [[au BufEnter * set fo-=c fo-=r fo-=o]]

--- a/lua/user/options.lua
+++ b/lua/user/options.lua
@@ -43,4 +43,5 @@ end
 
 vim.cmd "set whichwrap+=<,>,[,],h,l"
 vim.cmd [[set iskeyword+=-]]
+-- vim.cmd "set formatoptions-=cro" -- This does not seem to work, so the command below replaces it. 
 vim.cmd [[au BufEnter * set fo-=c fo-=r fo-=o]]

--- a/lua/user/options.lua
+++ b/lua/user/options.lua
@@ -43,4 +43,5 @@ end
 
 vim.cmd "set whichwrap+=<,>,[,],h,l"
 vim.cmd [[set iskeyword+=-]]
-vim.cmd [[set formatoptions-=cro]] -- TODO: this doesn't seem to work
+vim.cmd [[au BufEnter * set fo-=c fo-=r fo-=o]]
+

--- a/lua/user/options.lua
+++ b/lua/user/options.lua
@@ -44,4 +44,3 @@ end
 vim.cmd "set whichwrap+=<,>,[,],h,l"
 vim.cmd [[set iskeyword+=-]]
 vim.cmd [[au BufEnter * set fo-=c fo-=r fo-=o]]
-


### PR DESCRIPTION
Based on: https://vi.stackexchange.com/a/17739.

Running `:verbose set fo?` shows `Last set from /usr/share/nvim/runtime/ftplugin/lua.vim line 20`, where the culprit lies.

You either have have to change that file, or replace `set formatoptions-=cro` with `au BufEnter * set fo-=c fo-=r fo-=o`, an autocommand which does the job after opening neovim as a temporary measure.