### PR TITLE
Change for format options to disable auto comment

### DIFF
--- a/lua/user/options.lua
+++ b/lua/user/options.lua
@@ -33,6 +33,11 @@ local options = {
   scrolloff = 8,                           -- is one of my fav
   sidescrolloff = 8,
   guifont = "monospace:h17",               -- the font used in graphical neovim applications
+  formatoptions = {
+    c = false, -- Automatically insert the current comment leader after hitting 'o' or 'O' in Normal mode.
+    r = false, -- Automatically insert the current comment leader after hitting <Enter> in Insert mode.
+    o = false, -- Auto-wrap comments using textwidth, inserting the current comment leader automatically.
+  },
 }
 
 vim.opt.shortmess:append "c"
@@ -43,4 +48,4 @@ end
 
 vim.cmd "set whichwrap+=<,>,[,],h,l"
 vim.cmd [[set iskeyword+=-]]
-vim.cmd [[set formatoptions-=cro]] -- TODO: this doesn't seem to work
+


### PR DESCRIPTION
vim.cmd [[set formatoptions-=cro]] -- TODO: this doesn't seem to work

Found that using the formatoptions in form of a table, and setting the options to false fixes the setting for -cro.