### PR TITLE
Fix #158 [nvim-cmp] documentation is deprecated

### DIFF
--- a/lua/user/cmp.lua
+++ b/lua/user/cmp.lua
@@ -117,8 +117,10 @@ cmp.setup {
     behavior = cmp.ConfirmBehavior.Replace,
     select = false,
   },
-  documentation = {
-    border = { "╭", "─", "╮", "│", "╯", "─", "╰", "│" },
+  window = {
+    documentation = {
+      border = { "╭", "─", "╮", "│", "╯", "─", "╰", "│" },
+    },
   },
   experimental = {
     ghost_text = false,


### PR DESCRIPTION
Even if this bug is fixed in the main branch, I suggest to fix it also in the `05-completion` branch so the experience for ones that follow Youtube playlist is without this hitch.

Error
![Screenshot 2022-07-28 at 12 10 53](https://user-images.githubusercontent.com/22257750/181483953-975650df-7629-4e5e-9b34-f7941cb79b6a.png)

Fix
![Screenshot 2022-07-28 at 12 12 30](https://user-images.githubusercontent.com/22257750/181484102-279d05bf-53bd-4552-92e7-09bfcd97a83b.png)

