### PR TITLE
Fix documentation is deprecated error

### DIFF
--- a/lua/user/cmp.lua
+++ b/lua/user/cmp.lua
@@ -117,7 +117,7 @@ cmp.setup {
     behavior = cmp.ConfirmBehavior.Replace,
     select = false,
   },
-  documentation = {
+  window = {
     border = { "╭", "─", "╮", "│", "╯", "─", "╰", "│" },
   },
   experimental = {


### PR DESCRIPTION
Fixes:
```
[nvim-cmp] documentation is deprecated.
[nvim-cmp] Please use window.documentation = cmp.config.window.bordered() instead.
```

Also fixes snippets not working and error:

```
Error executing vim.schedule lua callback: ...te/pack/packer/start/nvim-cmp/lua/cmp/view/docs_view.lua:38: bad argument #1 to 'min' (number expected, got nil)
stack traceback:
        [C]: in function 'min'
        ...te/pack/packer/start/nvim-cmp/lua/cmp/view/docs_view.lua:38: in function 'open'
        ...re/nvim/site/pack/packer/start/nvim-cmp/lua/cmp/view.lua:238: in function 'callback'
        .../site/pack/packer/start/nvim-cmp/lua/cmp/utils/async.lua:95: in function 'cb'
        vim/_editor.lua:256: in function <vim/_editor.lua:256>
```