### PR TITLE
Update deprecated option in treesitter.lua

### DIFF
--- a/lua/user/treesitter.lua
+++ b/lua/user/treesitter.lua
@@ -14,7 +14,7 @@
 
 local configs = require("nvim-treesitter.configs")
 configs.setup {
-  ensure_installed = "maintained",
+  ensure_installed = "all",
   sync_install = false, 
   ignore_install = { "" }, -- List of parsers to ignore installing
   highlight = {


### PR DESCRIPTION
Hey Chris,
I copied your treesitter.lua config and it crashed because of ensure_installed option was set to "maintained".
It looks like it was already deprecated and so I suggest to replace it by ensure_installed="all".