### PR TITLE
Fix client.resolved_capabilities is deprecated

### DIFF
--- a/lua/user/lsp/handlers.lua
+++ b/lua/user/lsp/handlers.lua
@@ -46,7 +46,7 @@ end
 
 local function lsp_highlight_document(client)
   -- Set autocommands conditional on server_capabilities
-  if client.resolved_capabilities.document_highlight then
+  if client.server_capabilities.documentHighlight then
     vim.api.nvim_exec(
       [[
       augroup lsp_document_highlight
@@ -86,7 +86,7 @@ end
 
 M.on_attach = function(client, bufnr)
   if client.name == "tsserver" then
-    client.resolved_capabilities.document_formatting = false
+    client.server_capabilities.documentFormattingProvider = false
   end
   lsp_keymaps(bufnr)
   lsp_highlight_document(client)


### PR DESCRIPTION
Full error:

```
[LSP] Accessing client.resolved_capabilities is deprecated, update your
plugins or configuration to access client.server_capabilities instead.
The new key/value pairs in server_capabilities directly match those
defined in the language server protocol.
```

Sources:
[nvim-lsconfig issue #1891](https://github.com/neovim/nvim-lspconfig/issues/1891)
[LSP Specifications](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocumentClientCapabilities)