### PR TITLE
Migrate options to setup

### DIFF
--- a/lua/user/nvim-tree.lua
+++ b/lua/user/nvim-tree.lua
@@ -1,100 +1,104 @@
 -- following options are the default
 -- each of these are documented in `:help nvim-tree.OPTION_NAME`
-vim.g.nvim_tree_icons = {
-  default = "",
-  symlink = "",
-  git = {
-    unstaged = "",
-    staged = "S",
-    unmerged = "",
-    renamed = "➜",
-    deleted = "",
-    untracked = "U",
-    ignored = "◌",
-  },
-  folder = {
-    default = "",
-    open = "",
-    empty = "",
-    empty_open = "",
-    symlink = "",
-  },
-}
 
 local status_ok, nvim_tree = pcall(require, "nvim-tree")
 if not status_ok then
-  return
+    return
 end
 
 local config_status_ok, nvim_tree_config = pcall(require, "nvim-tree.config")
 if not config_status_ok then
-  return
+    return
 end
 
 local tree_cb = nvim_tree_config.nvim_tree_callback
 
 nvim_tree.setup {
-  disable_netrw = true,
-  hijack_netrw = true,
-  open_on_setup = false,
-  ignore_ft_on_setup = {
-    "startify",
-    "dashboard",
-    "alpha",
-  },
-  auto_close = true,
-  open_on_tab = false,
-  hijack_cursor = false,
-  update_cwd = true,
-  update_to_buf_dir = {
-    enable = true,
-    auto_open = true,
-  },
-  diagnostics = {
-    enable = true,
-    icons = {
-      hint = "",
-      info = "",
-      warning = "",
-      error = "",
+    disable_netrw = true,
+    hijack_netrw = true,
+    open_on_setup = false,
+    ignore_ft_on_setup = {
+        "startify",
+        "dashboard",
+        "alpha",
     },
-  },
-  update_focused_file = {
-    enable = true,
+    open_on_tab = false,
+    hijack_cursor = false,
     update_cwd = true,
-    ignore_list = {},
-  },
-  git = {
-    enable = true,
-    ignore = true,
-    timeout = 500,
-  },
-  view = {
-    width = 30,
-    height = 30,
-    hide_root_folder = false,
-    side = "left",
-    auto_resize = true,
-    mappings = {
-      custom_only = false,
-      list = {
-        { key = { "l", "<CR>", "o" }, cb = tree_cb "edit" },
-        { key = "h", cb = tree_cb "close_node" },
-        { key = "v", cb = tree_cb "vsplit" },
-      },
+    hijack_directories = {
+        enable = true,
+        auto_open = true,
     },
-    number = false,
-    relativenumber = false,
-  },
-  quit_on_open = 0,
-  git_hl = 1,
-  disable_window_picker = 0,
-  root_folder_modifier = ":t",
-  show_icons = {
-    git = 1,
-    folders = 1,
-    files = 1,
-    folder_arrows = 1,
-    tree_width = 30,
-  },
+    diagnostics = {
+        enable = true,
+        icons = {
+            hint = "",
+            info = "",
+            warning = "",
+            error = "",
+        },
+    },
+    update_focused_file = {
+        enable = true,
+        update_cwd = true,
+        ignore_list = {},
+    },
+    git = {
+        enable = true,
+        ignore = true,
+        timeout = 500,
+    },
+    view = {
+        width = 30,
+        height = 30,
+        hide_root_folder = false,
+        side = "left",
+        auto_resize = true,
+        mappings = {
+            custom_only = false,
+            list = {
+            { key = { "l", "<CR>", "o" }, cb = tree_cb "edit" },
+            { key = "h", cb = tree_cb "close_node" },
+            { key = "v", cb = tree_cb "vsplit" },
+            },
+        },
+        number = false,
+        relativenumber = false,
+    },
+    actions = {
+        quit_on_open = true,
+        window_picker = { enable = true },
+    },
+    renderer = {
+        highlight_git = true,
+        root_folder_modifier = ":t",
+        icons = {
+            show = {
+                file = true,
+                folder = true,
+                folder_arrow = true,
+                git = true,
+            },
+            glyphs = {
+                default = "",
+                symlink = "",
+                git = {
+                    unstaged = "",
+                    staged = "S",
+                    unmerged = "",
+                    renamed = "➜",
+                    deleted = "",
+                    untracked = "U",
+                    ignored = "◌",
+                },
+                folder = {
+                    default = "",
+                    open = "",
+                    empty = "",
+                    empty_open = "",
+                    symlink = "",
+                },
+            }
+        }
+    }
 }


### PR DESCRIPTION
This migrates and renamed the following options to `nvim_tree.setup` in accordance to nvim-tree migration guide:

* `vim.g.nvim_tree_icons` -> moved to `setup.renderer.icons.glyphs`
* `setup.auto_close` -> feature has been removed
* `setup.update_to_buf_dir` -> renamed to `hijack_directories`
* `setup.quit_on_open` -> moved to setup.actions.open_file
* `setup.git_hl` -> renamed to `highlight_git` and moved to `setup.renderer`
* `setup.disable_window_picker` -> renamed to `window_picker` and moved to `setup.actions`
* `setup.root_folder_modifier` -> moved to `setup.renderer`
* `setup.show_icons` -> moved to `setup.renderer.icons.show`; removed `tree_width`

Migration guide: https://github.com/kyazdani42/nvim-tree.lua/issues/674
`nvim-tree` docs : https://github.com/kyazdani42/nvim-tree.lua/blob/master/doc/nvim-tree-lua.txt