### PR TITLE
Fix of a breaking change in the last version of vim-cmp

### DIFF
--- a/lua/user/cmp.lua
+++ b/lua/user/cmp.lua
@@ -119,6 +119,9 @@ cmp.setup {
   },
   documentation = {
     border = { "╭", "─", "╮", "│", "╯", "─", "╰", "│" },
+    max_width = 50,
+    max_height = 80,
+
   },
   experimental = {
     ghost_text = false,


### PR DESCRIPTION
I'm not sure whether it is a bug or a breaking change, but this config stopped working without specifying the `max_width` & `max_height`. How to reproduce the error:
1. open a .lua file
2. print `fn` somewhere
3. pres `<tab>` twice

The line in the vim-cmp that breaks documentation popup:
https://github.com/hrsh7th/nvim-cmp/blob/main/lua/cmp/view/docs_view.lua#L39

![Screenshot 2022-09-09  14 07 12@2x](https://user-images.githubusercontent.com/11693557/189283051-4d5c858e-6ae0-4565-9084-f8475f3a22d2.png)
