### PR TITLE
fix: gitsigns, [nvimtree] unknown option: view.height

### DIFF
--- a/lua/user/gitsigns.lua
+++ b/lua/user/gitsigns.lua
@@ -3,47 +3,34 @@ if not status_ok then
   return
 end
 
--- gitsigns.setup {
---   signs = {
---     add = { hl = "GitSignsAdd", text = "▎", numhl = "GitSignsAddNr", linehl = "GitSignsAddLn" },
---     change = { hl = "GitSignsChange", text = "▎", numhl = "GitSignsChangeNr", linehl = "GitSignsChangeLn" },
---     delete = { hl = "GitSignsDelete", text = "契", numhl = "GitSignsDeleteNr", linehl = "GitSignsDeleteLn" },
---     topdelete = { hl = "GitSignsDelete", text = "契", numhl = "GitSignsDeleteNr", linehl = "GitSignsDeleteLn" },
---     changedelete = { hl = "GitSignsChange", text = "▎", numhl = "GitSignsChangeNr", linehl = "GitSignsChangeLn" },
---   },
---   signcolumn = true, -- Toggle with `:Gitsigns toggle_signs`
---   numhl = false, -- Toggle with `:Gitsigns toggle_numhl`
---   linehl = false, -- Toggle with `:Gitsigns toggle_linehl`
---   word_diff = false, -- Toggle with `:Gitsigns toggle_word_diff`
---   watch_gitdir = {
---     interval = 1000,
---     follow_files = true,
---   },
---   attach_to_untracked = true,
---   current_line_blame = false, -- Toggle with `:Gitsigns toggle_current_line_blame`
---   current_line_blame_opts = {
---     virt_text = true,
---     virt_text_pos = "eol", -- 'eol' | 'overlay' | 'right_align'
---     delay = 1000,
---     ignore_whitespace = false,
---   },
---   current_line_blame_formatter_opts = {
---     relative_time = false,
---   },
---   sign_priority = 6,
---   update_debounce = 100,
---   status_formatter = nil, -- Use default
---   max_file_length = 40000,
---   preview_config = {
---     -- Options passed to nvim_open_win
---     border = "single",
---     style = "minimal",
---     relative = "cursor",
---     row = 0,
---     col = 1,
---   },
---   yadm = {
---     enable = false,
---   },
--- }
-
+gitsigns.setup {
+  signs = {
+    add = { hl = "GitSignsAdd", text = "▎", numhl = "GitSignsAddNr", linehl = "GitSignsAddLn" },
+    change = { hl = "GitSignsChange", text = "▎", numhl = "GitSignsChangeNr", linehl = "GitSignsChangeLn" },
+    delete = { hl = "GitSignsDelete", text = "契", numhl = "GitSignsDeleteNr", linehl = "GitSignsDeleteLn" },
+    topdelete = { hl = "GitSignsDelete", text = "契", numhl = "GitSignsDeleteNr", linehl = "GitSignsDeleteLn" },
+    changedelete = { hl = "GitSignsChange", text = "▎", numhl = "GitSignsChangeNr", linehl = "GitSignsChangeLn" },
+  },
+  signcolumn = true, -- Toggle with `:Gitsigns toggle_signs`
+  watch_gitdir = {
+    interval = 1000,
+    follow_files = true,
+  },
+  attach_to_untracked = true,
+  current_line_blame_opts = {
+    virt_text = true,
+    virt_text_pos = "eol", -- 'eol' | 'overlay' | 'right_align'
+    delay = 1000,
+  },
+  sign_priority = 6,
+  update_debounce = 100,
+  status_formatter = nil, -- Use default
+  preview_config = {
+    -- Options passed to nvim_open_win
+    border = "single",
+    style = "minimal",
+    relative = "cursor",
+    row = 0,
+    col = 1,
+  },
+}

--- a/lua/user/nvim-tree.lua
+++ b/lua/user/nvim-tree.lua
@@ -55,7 +55,6 @@ nvim_tree.setup {
   },
   view = {
     width = 30,
-    height = 30,
     side = "left",
     mappings = {
       list = {


### PR DESCRIPTION
There was the following error:
```
Error processing InsertEnter Autocommands for "*":
Error detected while processing InsertEnter Autocommands for "*":
E5108: Error executing lua /usr/local/share/nvim/runtime/lua/vim/lsp.lua:1513:
attempt to call field 'is_closing' (a nil value)
stack traceback:
        /usr/local/share/nvim/runtime/lua/vim/lsp.lua:1513: in function 'is_sto
pped'
        ...ck/packer/start/cmp-nvim-lsp/lua/cmp_nvim_lsp/source.lua:16: in func
tion 'is_available'
        ...pack/packer/start/cmp-nvim-lsp/lua/cmp_nvim_lsp/init.lua:57: in func
tion '_on_insert_enter'
        [string ":lua"]:1: in main chunk
```
The remedy was to use gitsigns.lua from @neovim-basic-ide, which omits the following lines (not sequential):
```
numhl = false, -- Toggle with `:Gitsigns toggle_numhl`
  linehl = false, -- Toggle with `:Gitsigns toggle_linehl`
  word_diff = false, -- Toggle with `:Gitsigns toggle_word_diff`

 current_line_blame = false, -- Toggle with `:Gitsigns toggle_current_line_blame`
 ignore_whitespace = false,
  },
  current_line_blame_formatter_opts = {
    relative_time = false,
 max_file_length = 40000,
},
  yadm = {
    enable = false,
```