### PR TITLE
Fix two diagnostic shortcuts by using updated telescope API

### DIFF
--- a/lua/user/whichkey.lua
+++ b/lua/user/whichkey.lua
@@ -132,11 +132,11 @@ local mappings = {
     name = "LSP",
     a = { "<cmd>lua vim.lsp.buf.code_action()<cr>", "Code Action" },
     d = {
-      "<cmd>Telescope lsp_document_diagnostics<cr>",
+      "<cmd>Telescope diagnostics bufnr=0<cr>",
       "Document Diagnostics",
     },
     w = {
-      "<cmd>Telescope lsp_workspace_diagnostics<cr>",
+      "<cmd>Telescope diagnostics<cr>",
       "Workspace Diagnostics",
     },
     f = { "<cmd>lua vim.lsp.buf.format{async=true}<cr>", "Format" },


### PR DESCRIPTION
This fixes the shortcuts `<leader>ld` and `<leader>lw` which broke because of Telescope's changed diagnostics API:

https://github.com/nvim-telescope/telescope.nvim/blob/master/doc/telescope_changelog.txt#L154-L155