### PR TITLE
Fix: changed deprecated function call

### DIFF
--- a/lua/user/lsp/handlers.lua
+++ b/lua/user/lsp/handlers.lua
@@ -76,7 +76,7 @@ local function lsp_keymaps(bufnr)
     bufnr,
     "n",
     "gl",
-    '<cmd>lua vim.lsp.diagnostic.show_line_diagnostics({ border = "rounded" })<CR>',
+    '<cmd>lua vim.diagnostic.open_float()<CR>',
     opts
   )
   vim.api.nvim_buf_set_keymap(bufnr, "n", "]d", '<cmd>lua vim.diagnostic.goto_next({ border = "rounded" })<CR>', opts)


### PR DESCRIPTION
https://neovim.io/doc/user/deprecated.html, under: LSP DIAGNOSTICS

Show_line_diagnostics was breaking my config (on NVIM v0.8.1); seems no longer supported.
It seems defined at line 73 as well, with a different binding.