### PR TITLE
change deprecated lsp plugin

### DIFF
--- a/lua/user/plugins.lua
+++ b/lua/user/plugins.lua
@@ -79,6 +79,7 @@ return packer.startup(function(use)
   use { "williamboman/mason-lspconfig.nvim", commit = "0051870dd728f4988110a1b2d47f4a4510213e31" }
 	use { "jose-elias-alvarez/null-ls.nvim", commit = "c0c19f32b614b3921e17886c541c13a72748d450" } -- for formatters and linters
   use { "RRethy/vim-illuminate", commit = "d6ca7f77eeaf61b3e6ce9f0e5a978d606df44298" }
+  use {"nvimtools/none-ls.nvim"}
 
 	-- Telescope
 	use { "nvim-telescope/telescope.nvim", commit = "76ea9a898d3307244dce3573392dcf2cc38f340f" }

--- a/lua/user/plugins.lua
+++ b/lua/user/plugins.lua
@@ -77,7 +77,6 @@ return packer.startup(function(use)
 	use { "neovim/nvim-lspconfig", commit = "f11fdff7e8b5b415e5ef1837bdcdd37ea6764dda" } -- enable LSP
   use { "williamboman/mason.nvim", commit = "c2002d7a6b5a72ba02388548cfaf420b864fbc12"} -- simple to use language server installer
   use { "williamboman/mason-lspconfig.nvim", commit = "0051870dd728f4988110a1b2d47f4a4510213e31" }
-	use { "jose-elias-alvarez/null-ls.nvim", commit = "c0c19f32b614b3921e17886c541c13a72748d450" } -- for formatters and linters
   use { "RRethy/vim-illuminate", commit = "d6ca7f77eeaf61b3e6ce9f0e5a978d606df44298" }
   use {"nvimtools/none-ls.nvim"}
 


### PR DESCRIPTION
`jose-elias-alvarez/null-ls.nvim` has been archived on Aug 12, 2023 and is [no longer maintained](https://github.com/jose-elias-alvarez/null-ls.nvim/issues/1621). The use of this plugin causes a bunch of warnings in neovim because of some functions being deprecated that are used in the plugin.

This PR changes the use of this plugin with `nvimtools/none-ls.nvim` which is the successor of the previous plugin. It uses the same API, so it shouldn't affect the functionality in which `null-ls.nvim` was previously utilized. 